### PR TITLE
chore: update version bump workflow to modify package.json directly

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -33,8 +33,8 @@ jobs:
           # Increment patch version
           NEW_VERSION="$major.$minor.$((patch + 1))"
 
-          # Update package.json
-          npm version $NEW_VERSION --no-git-tag-version
+          # Update package.json directly
+          node -e "const pkg = require('./package.json'); pkg.version = '$NEW_VERSION'; require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
 
           # Commit and push changes
           git config --global user.name "GitHub Actions"


### PR DESCRIPTION
- Changed the method of updating the package.json version to directly modify the file using a Node.js script instead of using npm command.
- This change enhances the workflow's efficiency by eliminating the need for an additional npm command.