### PR TITLE
chore: update version bump workflow to use PERSONAL_ACCESS_TOKEN for …

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
-          token: ${{ secrets.AUTH_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,4 +41,4 @@ jobs:
           git config --global user.email "actions@github.com"
           git add package.json
           git commit -m "Bump version to $NEW_VERSION"
-          git push https://${{ secrets.AUTH_TOKEN }}@github.com/${{ github.repository }}.git HEAD:master
+          git push https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git HEAD:master


### PR DESCRIPTION
…git push

- Replaced AUTH_TOKEN with PERSONAL_ACCESS_TOKEN for git push in the version bump workflow to enhance security and access control.
- Ensured proper authentication during the version bump process by updating the token used in the push command.